### PR TITLE
Corrects #19 and upgrades plugin's compatibility to Confluence 5.9.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>raju.kadam.confluence</groupId>
     <artifactId>permissionmgmt</artifactId>
-    <version>2.3.0</version>
+    <version>2.3.1-SNAPSHOT</version>
 
     <name>Custom Space User Management Plugin</name>
     <url>http://confluence.atlassian.com/display/CONFEXT/Custom+Space+User+Management+Plugin</url>
@@ -22,7 +22,7 @@
     <packaging>atlassian-plugin</packaging>
 
     <properties>
-        <confluence.version>5.2.3</confluence.version>
+        <confluence.version>5.9.2</confluence.version>
         <!-- Look at pom.xml in confluence version in https://maven.atlassian.com/content/repositories/atlassian-public/com/atlassian/confluence/confluence-project/ -->
         <!-- Confluence version -->
         <atlassian.product.version>2.9</atlassian.product.version>
@@ -37,6 +37,13 @@
         <url>http://developer.atlassian.com/jira/browse/SUSR</url>
     </issueManagement>
 
+
+    <!-- If code if officially hosted on github, this section could be updated-->
+    <!--<scm>-->
+        <!--<connection>https://github.com/sillycat/confluence-space-user-management.git</connection>-->
+        <!--<developerConnection>https://github.com/sillycat/confluence-space-user-management.git</developerConnection>-->
+        <!--<url>https://github.com/sillycat/confluence-space-user-management</url>-->
+    <!--</scm>-->
     <scm>
         <connection>scm:svn:http://studio.plugins.atlassian.com/svn/SUSR/trunk</connection>
         <developerConnection>scm:svn:https://studio.plugins.atlassian.com/svn/SUSR/trunk</developerConnection>


### PR DESCRIPTION
The error described by rorydavidson and  NicolasEsteves  came from a change of java apis. The fix consisted in correcting the faulty api calls. I also replaced some deprecated calls. Not all deprecated uses have been changed.

In order to build the plugin I also had to add dependencies to the pom which I haven't commited , namely: 
```xml
    <dependency>
      <groupId>org.apache.axis</groupId>
       <artifactId>axis</artifactId>
       <version>1.4</version>
    </dependency>
    <dependency>
       <groupId>javax.xml</groupId>
       <artifactId>jaxrpc-api</artifactId>
       <version>1.1.1</version>
    </dependency>
```
I can still commit these changes if needed.

Overview of the changes : 
 - Switches some calls to deprecated getRemoteUser method to use getAuthenticatedUser instead (as stated in https://docs.atlassian.com/confluence/latest/index.html?com/atlassian/confluence/plugin/webresource/ConfluenceWebResourceManager.html)
 - Switches WebResourceManager to ConfluenceWebResourceService (as stated in https://docs.atlassian.com/confluence/latest/com/atlassian/confluence/plugin/webresource/ConfluenceWebResourceManager.html)
 - Corrects call to spaceDao.getSpaces to pass mandatory SpaceQueryWithPermissionBuilder
 - Switches call to spacePermissionManager.hasPermission to spacePermission.hasAllPermissions (as stated in https://docs.atlassian.com/confluence/latest/index.html?com/atlassian/confluence/plugin/webresource/ConfluenceWebResourceManager.html)