### PR TITLE
Corrects third party crashes when latest version of CSUM is installed

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -181,12 +181,14 @@
 	      <groupId>org.apache.axis</groupId>
 	       <artifactId>axis</artifactId>
 	       <version>1.4</version>
+            <scope>provided</scope>
 	    </dependency>
 
 	    <dependency>
 	       <groupId>javax.xml</groupId>
 	       <artifactId>jaxrpc-api</artifactId>
 	       <version>1.1</version>
+            <scope>provided</scope>
 	    </dependency>
 
         <dependency>


### PR DESCRIPTION
When the latest version of CSUM is installed on Confluence (tested on v5.9.2), some third party plugins might crash (ex: Run CLI by Bob Swift) because of the scope of the dependencies introduced in the plugin's upgrade. The crash is only detected after a restart of Confluence.

This modification simply switches the scope from 'compile' which embeds the dependencies as stated in the version to 'provided' which tells java the librairies in question will be present on the container.
